### PR TITLE
Add profile to load a custom db artifact

### DIFF
--- a/komet/application/pom.xml
+++ b/komet/application/pom.xml
@@ -18,6 +18,7 @@
         <log4j.version>2.8.1</log4j.version>
         <solor.db.version>1.27</solor.db.version>
         <solor.snap.db.version>1.27</solor.snap.db.version>
+        <custom.db.version>1.0.0</custom.db.version>
     </properties>
 
     <organization>
@@ -33,7 +34,7 @@
         <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
-        </dependency>      
+        </dependency>
         <dependency>
             <groupId>org.jfxtras</groupId>
             <artifactId>jfxtras-controls</artifactId>
@@ -270,8 +271,8 @@
                         <!-- Let JUnit annotations decide -->
                         <include>**/*.class</include>
                     </includes>
-                    <!--systemPropertyVariables> 
-                        <org.ihtsdo.otf.tcc.query.lucene-root-location>${project.build.directory}</org.ihtsdo.otf.tcc.query.lucene-root-location> 
+                    <!--systemPropertyVariables>
+                        <org.ihtsdo.otf.tcc.query.lucene-root-location>${project.build.directory}</org.ihtsdo.otf.tcc.query.lucene-root-location>
                     </systemPropertyVariables-->
                 </configuration>
             </plugin>
@@ -282,14 +283,14 @@
                     <execution>
                         <id>default-cli</id>
                         <goals>
-                            <goal>java</goal>                            
+                            <goal>java</goal>
                         </goals>
                         <configuration>
                             <mainClass>${mainClass}</mainClass>
                             <!--<arguments>-Xdebug -Xrunjdwp:transport="dt_socket,suspend=y,server=n,address=8888" -Dglass.disableGrab=true -jar "${project.build.directory}/${project.build.finalName}.jar" </arguments>-->
                         </configuration>
                     </execution>
-                </executions>  
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.zenjava</groupId>
@@ -303,12 +304,12 @@
                     <vendor>ISAAC's KOMET collaboration</vendor>
                     <additionalAppResources>${project.build.directory}/data</additionalAppResources>
                     <detail>true</detail>
-                    <skipNativeVersionNumberSanitizing>true</skipNativeVersionNumberSanitizing>   
+                    <skipNativeVersionNumberSanitizing>true</skipNativeVersionNumberSanitizing>
                     <jvmArgs>
                         <jvmArg>-Xms4G</jvmArg>
                         <jvmArg>-Xmx16G</jvmArg>
-                    </jvmArgs>               
-                    <bundleArguments>              
+                    </jvmArgs>
+                    <bundleArguments>
                         <icon.ico>${project.basedir}/src/main/resources/icons/KOMET.ico</icon.ico>
                         <icon.png>${project.basedir}/src/main/resources/icons/KOMET.png</icon.png>
                         <icon.icns>${project.basedir}/src/main/resources/icons/KOMET.icns</icon.icns>
@@ -331,7 +332,7 @@
                        </goals>
                     </execution>-->
                 </executions>
-            </plugin>      
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -367,7 +368,7 @@
                                 <configuration>
                                     <bundler>dmg</bundler>
                                 </configuration>
-                            </execution>                
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -390,7 +391,7 @@
                 </dependency>
             </dependencies>
         </profile>
-    
+
         <profile>
             <id>external-plugins</id>
             <activation>
@@ -464,6 +465,51 @@
                                             <groupId>one.solor</groupId>
                                             <artifactId>solor-snap-db</artifactId>
                                             <version>${solor.snap.db.version}</version>
+                                            <type>zip</type>
+                                        </artifact>
+                                    </artifactItems>
+                                    <outputDirectory>${project.build.directory}/data/isaac.data/</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>custom-database</id>
+            <activation>
+                <property>
+                    <name>database</name>
+                    <value>custom</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>${database.groupId}</groupId>
+                    <artifactId>${database.artifactId}</artifactId>
+                    <version>${custom.db.version}</version>
+                    <type>zip</type>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>extract-solor-datastore</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifact>
+                                            <groupId>${database.groupId}</groupId>
+                                            <artifactId>${database.artifactId}</artifactId>
+                                            <version>${custom.db.version}</version>
                                             <type>zip</type>
                                         </artifact>
                                     </artifactItems>


### PR DESCRIPTION
This PR adds a profile to the KOMET pom that allows a developer to specify a custom database artifact fashioned after `solor-snap-db`. The version number of the artifact is specified in the pom. All other properties must be supplied via the user's settings file.